### PR TITLE
Add newly commited tutorials link and change links for JSBIN to hookup

### DIFF
--- a/gc/top/examples/index.html
+++ b/gc/top/examples/index.html
@@ -24,6 +24,9 @@ body{
   margin:0 auto;
   margin-bottom:20px;
 }
+.index{
+  background-color:rgba(240,240,240,0.8);
+}
 .outgpio{
   background-color:rgba(192,192,255,0.7);
 }
@@ -172,361 +175,443 @@ parts,sumally{
 </style>
 </head>
 <body>
+
+<div class="outwrap index">
+  <div class="colwrap">
+    <div class="twrap gpio">
+      <H2>INDEX</H2>
+      <ul>
+        <li><a href="#gpioExamples">GPIO Examples</a>
+        <li><a href="#i2cExamples">I2C Examples</a>
+    </div>
+  </div>
+</div>
+
 <div class="outwrap outgpio">
-<div class="colwrap">
-  <div class="twrap gpio">
-    <h1>GPIO Examples (<a href="https://rawgit.com/browserobo/WebGPIO/master/index.html">API Spec</a>)</h1>
+  <div class="colwrap">
+    <div class="twrap gpio">
+      <h1 id="gpioExamples">GPIO Examples (<a href="https://rawgit.com/browserobo/WebGPIO/master/index.html">API Spec</a>)</h1>
+    </div>
+  </div>
+  
+  <div class="rowwrap">
+    <div class="cwrap">
+      <div class="title">GPIO-Blink</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../gpio/LEDblink/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../gpio/LEDblink/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/GPIO-Blink.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">LEDを点滅させます。</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li>LED x 1</li>
+          <li>抵抗（100Ω〜470Ω） x 1<BR>(220Ωのカラーコード:赤赤茶金)</li>
+          <li>ジャンパー（オス・メス）ケーブル x 2</li>
+          <li>ブレッドボード x 1</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="cwrap">
+      <div class="title">GPIO-Button</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../gpio/button/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../gpio/button/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/GPIO-Button.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">タクトスイッチを押すとLEDが点灯、離すと消灯します。<br>このサンプルでは、GPIOポートの読み込みに、<b>onchange()</b> を用いています。</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li>タクトスイッチ x 1</li>
+          <li>LED x 1</li>
+          <li>抵抗（100Ω〜470Ω） x 1<BR>(220Ωのカラーコード:赤赤茶金)</li>
+          <li>ジャンパー（オス・メス）ケーブル x 4</li>
+          <li>ブレッドボード x 1</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="cwrap">
+      <div class="title">GPIO-readGpioValue</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../gpio/readGpioValue/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../gpio/readGpioValue/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/GPIO-readGpioValue.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">タクトスイッチの状態（押されているか、押されていないか）を読み込みコンソールへLog出力します。<br>このサンプルでは、GPIOポートの読み込みを <b>read()</b> を用いたポーリング処理で実現しています。</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li>タクトスイッチ x 1</li>
+          <li>ジャンパー（オス・メス）ケーブル x 2</li>
+          <li>ブレッドボード x 1</li>
+        </ul>
+      </div>
+    </div>
+    
+    <div class="cwrap">
+      <div class="title">GPIO-pirSensor</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../gpio/pirSensor/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../gpio/pirSensor/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/GPIO-pirSensor.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">人感センサーをGPIOで読み取り、画面に反映させます</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li>人感センサー (KP-IR412) x 1</li>
+          <li>ジャンパー（オス・メス）ケーブル x 6</li>
+          <li>ブレッドボード x 1</li>
+        </ul>
+      </div>
+    </div>
+    
+    <div class="cwrap">
+      <div class="title">GPIO-MultiBlinkAll</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="https://gist.github.com/satakagi/24d30e9a5a07ea79554872084ac7c641" target="_blank">解説記事</a></div>
+        <div class="linkicon local"><a href="../../gpio/MultiBlinkAll/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/GPIO-MultiBlinkAll.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">大量のLEDをLチカさせます</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li>LED x 8</li>
+          <li>抵抗器 (470Ω : 黄紫茶金) x 8</li>
+          <li>ジャンパー（オス・メス）ケーブル x 9</li>
+          <li>ジャンパー（オス・オス）ケーブル x 2</li>
+          <li>ブレッドボード x 1</li>
+        </ul>
+      </div>
+    </div>
+    
+    <!-- TBD wait for GPIO in bug fix
+    <div class="cwrap">
+      <div class="title">GPIO-buttonAll</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="." target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../gpio/buttonAll/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://jsbin.com/suzetumupe/edit?html,js,output" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">大量のタクトスイッチの入力を得ます</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li>タクトスイッチ x 8</li>
+          <li>ジャンパー（オス・メス）ケーブル x 9</li>
+          <li>ジャンパー（オス・オス）ケーブル x 8</li>
+          <li>ブレッドボード x 1</li>
+        </ul>
+      </div>
+    </div>
+    -->
+    
   </div>
 </div>
-<div class="rowwrap">
 
-  <div class="cwrap">
-    <div class="title">GPIO-Blink</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../gpio/LEDblink/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../gpio/LEDblink/" target="_blank">Local</a></div>
-      <div class="linkicon jsbin"><a href="https://jsbin.com/muqowaneni/edit?html,js,output" target="_blank">JSBin</a></div>
-    </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">LEDを点滅させます。</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li>LED x 1</li>
-        <li>抵抗（100Ω〜470Ω） x 1</li>
-        <li>ジャンパー（オス・メス）ケーブル x 2</li>
-        <li>ブレッドボード x 1</li>
-      </ul>
-    </div>
-  </div>
-
-  <div class="cwrap">
-    <div class="title">GPIO-Button</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../gpio/button/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../gpio/button/" target="_blank">Local</a></div>
-      <div class="linkicon jsbin"><a href="https://jsbin.com/socoyakeyo/edit?html,js,output" target="_blank">JSBin</a></div>
-    </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">タクトスイッチを押すとLEDが点灯、離すと消灯します。<br>このサンプルでは、GPIOポートの読み込みに、<b>onchange()</b> を用いています。</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li>タクトスイッチ x 1</li>
-        <li>LED x 1</li>
-        <li>抵抗（100Ω〜470Ω） x 1</li>
-        <li>ジャンパー（オス・メス）ケーブル x 4</li>
-        <li>ブレッドボード x 1</li>
-      </ul>
-    </div>
-  </div>
-
-  <div class="cwrap">
-    <div class="title">GPIO-readGpioValue</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../gpio/readGpioValue/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../gpio/readGpioValue/" target="_blank">Local</a></div>
-      <div class="linkicon jsbin"><a href="https://jsbin.com/suzetumupe/edit?html,js,output" target="_blank">JSBin</a></div>
-    </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">タクトスイッチの状態（押されているか、押されていないか）を読み込みコンソールへLog出力します。<br>このサンプルでは、GPIOポートの読み込みを <b>read()</b> を用いたポーリング処理で実現しています。</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li>タクトスイッチ x 1</li>
-        <li>ジャンパー（オス・メス）ケーブル x 2</li>
-        <li>ブレッドボード x 1</li>
-      </ul>
-    </div>
-  </div>
-
-</div>
-</div>
 <div class="outwrap outi2c">
-<div class="colwrap">
-  <div class="twrap i2c">
-    <h1>I2C Examples (<a href="https://rawgit.com/browserobo/WebI2C/master/index.html">API Spec</a>)</h1>
-  </div>
-</div>
-<div class="rowwrap">
-
-  <div class="cwrap">
-    <div class="title">I2C-ADT7410</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-ADT7410/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-ADT7410/" target="_blank">Local</a></div>
-      <div class="linkicon jsbin"><a href="https://jsbin.com/finefuquhu/edit?html,js,output" target="_blank">JSBin</a></div>
-    </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">I2C接続の温度センサー「ADT7410」を用いて温度を計測し表示します。（このセンサーは4本のピンヘッダ経由で接続します。あらかじめピンヘッダをハンダ付けしておいてください。 <br><span style="font-size:11px;">※ジャンパー（メス・メス）ケーブルに直接刺すために、パッケージに付属の細ピンヘッダではなく標準サイズのピンヘッダを付けてください）</span></div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="http://akizukidenshi.com/catalog/g/gM-06675/">ADT7410使用高精度・高分解能I2C・16Bit温度センサモジュール</a> ）x 1</li>
-        <li>ジャンパー（メス・メス）ケーブル x 4</li>
-      </ul>
+  <div class="colwrap">
+    <div class="twrap i2c">
+      <h1 id="i2cExamples">I2C Examples (<a href="https://rawgit.com/browserobo/WebI2C/master/index.html">API Spec</a>)</h1>
     </div>
   </div>
+  
+  <div class="rowwrap">
+    <div class="cwrap">
+      <div class="title">I2C-ADT7410</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-ADT7410/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-ADT7410/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-ADT7410.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">I2C接続の温度センサー「ADT7410」を用いて温度を計測し表示します。（このセンサーは4本のピンヘッダ経由で接続します。あらかじめピンヘッダをハンダ付けしておいてください。 <br><span style="font-size:11px;">※ジャンパー（メス・メス）ケーブルに直接刺すために、パッケージに付属の細ピンヘッダではなく標準サイズのピンヘッダを付けてください）</span></div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="http://akizukidenshi.com/catalog/g/gM-06675/">ADT7410使用高精度・高分解能I2C・16Bit温度センサモジュール</a> ）x 1</li>
+          <li>ジャンパー（メス・メス）ケーブル x 4</li>
+        </ul>
+      </div>
+    </div>
 
-  <div class="cwrap">
-    <div class="title">I2C-Grove-Accelerometer</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-grove-accelerometer/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-grove-accelerometer/" target="_blank">Local</a></div>
-      <div class="linkicon jsbin"><a href="https://jsbin.com/subatetexa/edit?html,js,output" target="_blank">JSBin</a></div>
+    <div class="cwrap">
+      <div class="title">I2C-Grove-Accelerometer</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-grove-accelerometer/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-grove-accelerometer/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-Grove-Accelerometer.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">I2C接続の3軸加速度センサーで取得した値を表示します。（このセンサーはGroveケーブル経由で接続します）</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="https://www.switch-science.com/catalog/972/">GROVE - I2C 三軸加速度センサ ADXL345搭載</a> x 1</li>
+          <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 1</li>
+        </ul>
+      </div>
     </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">I2C接続の3軸加速度センサーで取得した値を表示します。（このセンサーはGroveケーブル経由で接続します）</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="https://www.switch-science.com/catalog/972/">GROVE - I2C 三軸加速度センサ ADXL345搭載</a> x 1</li>
-        <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 1</li>
-      </ul>
-    </div>
-  </div>
 
-  <div class="cwrap">
-    <div class="title">I2C-Grove-Gesture</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-grove-gesture/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-grove-gesture/" target="_blank">Local</a></div>
-      <div class="linkicon jsbin"><a href="https://jsbin.com/hewetagazo/edit?html,js,output" target="_blank">JSBin</a></div>
+    <div class="cwrap">
+      <div class="title">I2C-Grove-Gesture</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-grove-gesture/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-grove-gesture/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-Grove-Gesture.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">I2C接続のジェスチャーセンサー（センサーの前で手などを動かすと動かした方向などのモーションを検出するセンサー）の検出結果を表示します。（このセンサーはGroveケーブル経由で接続します）</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="https://www.switch-science.com/catalog/2645/">GROVE - ジェスチャー</a> x 1</li>
+          <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 1</li>
+        </ul>
+      </div>
     </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">I2C接続のジェスチャーセンサー（センサーの前で手などを動かすと動かした方向などのモーションを検出するセンサー）の検出結果を表示します。（このセンサーはGroveケーブル経由で接続します）</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="https://www.switch-science.com/catalog/2645/">GROVE - ジェスチャー</a> x 1</li>
-        <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 1</li>
-      </ul>
-    </div>
-  </div>
 
-  <div class="cwrap">
-    <div class="title">I2C-Grove-Light</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-grove-light/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-grove-light/" target="_blank">Local</a></div>
-      <div class="linkicon jsbin"><a href="https://jsbin.com/latosatopo/edit?html,js,output" target="_blank">JSBin</a></div>
+    <div class="cwrap">
+      <div class="title">I2C-Grove-Light</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-grove-light/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-grove-light/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-Grove-Light.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">I2C接続の光センサーで取得した明るさを表示します。（このセンサーはGroveケーブル経由で接続します）</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="https://www.switch-science.com/catalog/1174/">GROVE - I2C デジタル光センサ</a> x 1</li>
+          <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 1</li>
+        </ul>
+      </div>
     </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">I2C接続の光センサーで取得した明るさを表示します。（このセンサーはGroveケーブル経由で接続します）</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="https://www.switch-science.com/catalog/1174/">GROVE - I2C デジタル光センサ</a> x 1</li>
-        <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 1</li>
-      </ul>
-    </div>
-  </div>
 
-  <div class="cwrap">
-    <div class="title">I2C-Grove-OledDisplay</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-grove-oledDisplay/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-grove-oledDisplay/" target="_blank">Local</a></div>
-      <div class="linkicon jsbin"><a href="https://jsbin.com/mociboteje/edit?html,js,output" target="_blank">JSBin</a></div>
+    <div class="cwrap">
+      <div class="title">I2C-Grove-OledDisplay</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-grove-oledDisplay/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-grove-oledDisplay/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-Grove-OledDisplay.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">I2C接続の小さなOLED（有機EL）ディスプレイへ文字を表示します。（このディスプレイはGroveケーブル経由で接続します）</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="https://www.switch-science.com/catalog/829/">GROVE - I2C OLEDディスプレイ128×64</a> x 1</li>
+          <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 1</li>
+        </ul>
+      </div>
     </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">I2C接続の小さなOLED（有機EL）ディスプレイへ文字を表示します。（このディスプレイはGroveケーブル経由で接続します）</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="https://www.switch-science.com/catalog/829/">GROVE - I2C OLEDディスプレイ128×64</a> x 1</li>
-        <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 1</li>
-      </ul>
-    </div>
-  </div>
 
-  <div class="cwrap">
-    <div class="title">I2C-Grove-Touch</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-grove-touch/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-grove-touch/" target="_blank">Local</a></div>
-      <div class="linkicon jsbin"><a href="https://jsbin.com/zaluwejeye/edit?html,js,output" target="_blank">JSBin</a></div>
+    <div class="cwrap">
+      <div class="title">I2C-Grove-Touch</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-grove-touch/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-grove-touch/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-Grove-Touch.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">I2C接続のタッチセンサー（静電容量式タッチキー）によるタッチ検出をおこないます。（このセンサーはGroveケーブル経由で接続します）</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="https://www.switch-science.com/catalog/825/">GROVE - I2C タッチセンサ</a> x 1</li>
+          <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 1</li>
+        </ul>
+      </div>
     </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">I2C接続のタッチセンサー（静電容量式タッチキー）によるタッチ検出をおこないます。（このセンサーはGroveケーブル経由で接続します）</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="https://www.switch-science.com/catalog/825/">GROVE - I2C タッチセンサ</a> x 1</li>
-        <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 1</li>
-      </ul>
-    </div>
-  </div>
 
-  <div class="cwrap">
-    <div class="title">I2C-PCA9685</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-PCA9685/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-PCA9685/" target="_blank">Local</a></div>
-      <div class="linkicon jsbin"><a href="https://jsbin.com/rifugopeko/edit?html,js,output" target="_blank">JSBin</a></div>
+    <div class="cwrap">
+      <div class="title">I2C-PCA9685</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-PCA9685/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-PCA9685/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-PCA9685.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">I2C接続のPWMドライバー経由でサーボモーターを駆動します。（RaspberryからPWMドライバーをI2C接続し、 PWMドライバとサーボモータ、外部電源を接続します。詳細は回路図を参照ください）</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="https://www.switch-science.com/catalog/961/">PCA9685搭載16チャネル PWM/サーボ ドライバー (I2C接続)</a> x 1</li>
+          <li><a href="http://akizukidenshi.com/catalog/g/gM-08761/">マイクロサーボ SG-90</a> x 1</li>
+          <li>ジャンパー（メス・メス）ケーブル x 4</li>
+        </ul>
+        上記に加え、外部電源確保のため下記 1. あるいは 2. が必要になります。
+        <ol>
+          <li><a href="http://akizukidenshi.com/catalog/g/gP-03087/">電池BOX(4本用)</a> x 1 <span style="font-size:11px">(※電池BOXを利用する場合、PCA9685サーボドライバとの接続用に電池BOX側の電源ケーブルの終端をメスに加工する等の工夫が必要です)</span></li>
+          <li><a href="http://akizukidenshi.com/catalog/g/gK-10972/">「電源用マイクロUSBコネクタDIP化キット</a> x 1」+「ブレッドボード x 1」「USB Micro B端子-標準A端子のケーブル x 1」+「スマホ用5V充電器 x 1」+ 「ジャンパー（メス・オス）ケーブル x 2」 </li>
+        </ol>
+      </div>
     </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">I2C接続のPWMドライバー経由でサーボモーターを駆動します。（RaspberryからPWMドライバーをI2C接続し、 PWMドライバとサーボモータ、外部電源を接続します。詳細は回路図を参照ください）</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="https://www.switch-science.com/catalog/961/">PCA9685搭載16チャネル PWM/サーボ ドライバー (I2C接続)</a> x 1</li>
-        <li><a href="http://akizukidenshi.com/catalog/g/gM-08761/">マイクロサーボ SG-90</a> x 1</li>
-        <li>ジャンパー（メス・メス）ケーブル x 4</li>
-      </ul>
-      上記に加え、外部電源確保のため下記 1. あるいは 2. が必要になります。
-      <ol>
-        <li><a href="http://akizukidenshi.com/catalog/g/gP-03087/">電池BOX(4本用)</a> x 1 <span style="font-size:11px">(※電池BOXを利用する場合、PCA9685サーボドライバとの接続用に電池BOX側の電源ケーブルの終端をメスに加工する等の工夫が必要です)</span></li>
-        <li><a href="http://akizukidenshi.com/catalog/g/gK-10972/">「電源用マイクロUSBコネクタDIP化キット</a> x 1」+「ブレッドボード x 1」「USB Micro B端子-標準A端子のケーブル x 1」+「スマホ用5V充電器 x 1」+ 「ジャンパー（メス・オス）ケーブル x 2」 </li>
-      </ol>
-    </div>
-  </div>
 
-  <div class="cwrap">
-    <div class="title">I2C-ADS1015</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-ADS1015/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-ADS1015/" target="_blank">Local</a></div>
+    <div class="cwrap">
+      <div class="title">I2C-ADS1015</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-ADS1015/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-ADS1015/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-ADS1015.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">I2C接続のADC（アナログ・デジタルコンバータ）経由で可変抵抗器の値を表示します。</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="https://www.switch-science.com/catalog/1136/">ADS1015搭載 12BitADC 4CH 可変ゲインアンプ付き</a> x 1 <span style="font-size:11px">製品パッケージに付属するピンヘッダのハンダづけが必要です。</span></li>
+          <li>10kΩ Bカーブ 可変抵抗器 x 1 <span style="font-size:11px">ブレッドボードに直接刺せるタイプのものが必要です。例えば<a href="https://www.switch-science.com/catalog/1039/">これ</a></span></li>
+          <li>1uF コンデンサ x 1</li>
+          <li>ジャンパー（オス・メス）ケーブル x 4</li>
+          <li>ジャンパー（オス・オス）ケーブル x 4</li>
+          <li>ブレッドボード x 1</li>
+        </ul>
+      </div>
     </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">I2C接続のADC（アナログ・デジタルコンバータ）経由で可変抵抗器の値を表示します。</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="https://www.switch-science.com/catalog/1136/">ADS1015搭載 12BitADC 4CH 可変ゲインアンプ付き</a> x 1 <span style="font-size:11px">製品パッケージに付属するピンヘッダのハンダづけが必要です。</span></li>
-        <li>10kΩ Bカーブ 可変抵抗器 x 1 <span style="font-size:11px">ブレッドボードに直接刺せるタイプのものが必要です。例えば<a href="https://www.switch-science.com/catalog/1039/">これ</a></span></li>
-        <li>1uF コンデンサ x 1</li>
-        <li>ジャンパー（オス・メス）ケーブル x 4</li>
-        <li>ジャンパー（オス・オス）ケーブル x 4</li>
-        <li>ブレッドボード x 1</li>
-      </ul>
-    </div>
-  </div>
 
-  <div class="cwrap">
-    <div class="title">I2C-GP2Y0E03</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-GP2Y0E03/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-GP2Y0E03/" target="_blank">Local</a></div>
+    <div class="cwrap">
+      <div class="title">I2C-GP2Y0E03</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-GP2Y0E03/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-GP2Y0E03/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-GP2Y0E03.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">I2C接続の赤外線測距センサー（センサーから障害物までの距離を測るセンサー）の値を表示します。（このセンサーはGroveケーブル経由で接続します）</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="http://akizukidenshi.com/catalog/g/gI-07547/">シャープ測距モジュールGP2Y0E03（I2C＆アナログ出力）</a> x 1 <span style="font-size:11px">(※製品パッケージに付属の細いケーブルをブレッドボードに刺せるようにするため、ピンヘッダをハンダ付けするかQIコネクタを圧着する等の加工が必要です)</span></li>
+          <li>ジャンパー（オス・メス）ケーブル x 4</li>
+          <li>ジャンパー（オス・オス）ケーブル x 2</li>
+          <li>ブレッドボード x 1</li>
+        </ul>
+      </div>
     </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">I2C接続の赤外線測距センサー（センサーから障害物までの距離を測るセンサー）の値を表示します。（このセンサーはGroveケーブル経由で接続します）</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="http://akizukidenshi.com/catalog/g/gI-07547/">シャープ測距モジュールGP2Y0E03（I2C＆アナログ出力）</a> x 1 <span style="font-size:11px">(※製品パッケージに付属の細いケーブルをブレッドボードに刺せるようにするため、ピンヘッダをハンダ付けするかQIコネクタを圧着する等の加工が必要です)</span></li>
-        <li>ジャンパー（オス・メス）ケーブル x 4</li>
-        <li>ジャンパー（オス・オス）ケーブル x 2</li>
-        <li>ブレッドボード x 1</li>
-      </ul>
-    </div>
-  </div>
 
-  <div class="cwrap">
-    <div class="title">I2C-S11059</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-S11059/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-S11059/" target="_blank">Local</a></div>
-    </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">I2C接続のRGBカラーセンサーで取得した値を表示します。（このセンサーは4本のピンヘッダ経由で接続します。あらかじめピンヘッダをハンダ付けしておいてください。 <br><span style="font-size:11px;">※ジャンパー（メス・メス）ケーブルに直接刺すために、パッケージに付属の細ピンヘッダではなく標準サイズのピンヘッダを付けてください）</span></div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="http://akizukidenshi.com/catalog/g/gK-08316/">
+    <div class="cwrap">
+      <div class="title">I2C-S11059</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-S11059/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-S11059/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-S11059.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">I2C接続のRGBカラーセンサーで取得した値を表示します。（このセンサーは4本のピンヘッダ経由で接続します。あらかじめピンヘッダをハンダ付けしておいてください。 <br><span style="font-size:11px;">※ジャンパー（メス・メス）ケーブルに直接刺すために、パッケージに付属の細ピンヘッダではなく標準サイズのピンヘッダを付けてください）</span></div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="http://akizukidenshi.com/catalog/g/gK-08316/">
 I2C対応デジタルカラーセンサモジュールS11059-02DT</a> x 1 <span style="font-size:11px">(※製品パッケージに付属の細いケーブルをブレッドボードに刺せるようにするため、ピンヘッダをハンダ付けするかQIコネクタを圧着する等の加工が必要です)</span></li>
-        <li>ジャンパー（メス・メス）ケーブル x 4</li>
-      </ul>
+          <li>ジャンパー（メス・メス）ケーブル x 4</li>
+        </ul>
+      </div>
     </div>
-  </div>
 
-  <div class="cwrap">
-    <div class="title">I2C-VEML6070</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-VEML6070/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-VEML6070/" target="_blank">Local</a></div>
+    <div class="cwrap">
+      <div class="title">I2C-VEML6070</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-VEML6070/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-VEML6070/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-VEML6070.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">I2C接続のUVセンサー（紫外線の強さを測定することができるセンサー）で取得した値を表示します。（このセンサーは4本のピンヘッダ経由で接続します。あらかじめピンヘッダをハンダ付けしておいてください）<br>なお、必須ではありませんが紫外線ライトがあるとテストが捗ります。</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="https://www.switch-science.com/catalog/2748/">VEML6070搭載 UVセンサボード</a> x 1 </li>
+          <li>ジャンパー（メス・メス）ケーブル x 4</li>
+        </ul>
+      </div>
     </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">I2C接続のUVセンサー（紫外線の強さを測定することができるセンサー）で取得した値を表示します。（このセンサーは4本のピンヘッダ経由で接続します。あらかじめピンヘッダをハンダ付けしておいてください）<br>なお、必須ではありませんが紫外線ライトがあるとテストが捗ります。</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="https://www.switch-science.com/catalog/2748/">VEML6070搭載 UVセンサボード</a> x 1 </li>
-        <li>ジャンパー（メス・メス）ケーブル x 4</li>
-      </ul>
-    </div>
-  </div>
 
-  <div class="cwrap">
-    <div class="title">I2C-multi-sensors</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-multi-sensors/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-multi-sensors/" target="_blank">Local</a></div>
+    <div class="cwrap">
+      <div class="title">I2C-multi-sensors</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-multi-sensors/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-multi-sensors/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-multi-sensors.md" target="_blank">JSBin</a></div>
+     </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">複数のセンサーを組み合わせて利用する場合のサンプルです。ここでは、ADT7410（温度センサー）と、Grove I2C デジタル光センサを接続し、それぞれのセンサーから取得した値を表示しています。複数のセンサーを接続する場合、Grove I2C ハブを利用すると便利です。</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="http://akizukidenshi.com/catalog/g/gM-06675/">ADT7410使用高精度・高分解能I2C・16Bit温度センサモジュール</a> ）x 1</li>
+          <li><a href="https://www.switch-science.com/catalog/1174/">GROVE - I2C デジタル光センサ</a> x 1</li>
+          <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 2</li>
+          <li><a href="https://www.switch-science.com/catalog/798/">Grove ケーブル</a> x 1</li>
+          <li><a href="https://www.switch-science.com/catalog/796/">Grove I2C ハブ</a> x 1 </li>
+        </ul>
+      </div>
     </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">複数のセンサーを組み合わせて利用する場合のサンプルです。ここでは、ADT7410（温度センサー）と、Grove I2C デジタル光センサを接続し、それぞれのセンサーから取得した値を表示しています。複数のセンサーを接続する場合、Grove I2C ハブを利用すると便利です。</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="http://akizukidenshi.com/catalog/g/gM-06675/">ADT7410使用高精度・高分解能I2C・16Bit温度センサモジュール</a> ）x 1</li>
-        <li><a href="https://www.switch-science.com/catalog/1174/">GROVE - I2C デジタル光センサ</a> x 1</li>
-        <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 2</li>
-        <li><a href="https://www.switch-science.com/catalog/798/">Grove ケーブル</a> x 1</li>
-        <li><a href="https://www.switch-science.com/catalog/796/">Grove I2C ハブ</a> x 1 </li>
-      </ul>
-    </div>
-  </div>
 
-  <div class="cwrap">
-    <div class="title">I2C-canzasi-blink</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-canzasi-blink/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-canzasi-blink/" target="_blank">Local</a></div>
+    <div class="cwrap">
+      <div class="title">I2C-canzasi-blink</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-canzasi-blink/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-canzasi-blink/" target="_blank">Local</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-canzasi-blink.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">Arduino経由でI2Cデバイスが作れるオープンソースハードウエア「<a href="https://github.com/tadfmac/Canzasi">Canzasi</a>」の接続例です。<br><span style="font-size:11px">Canzasiを利用するためには、Arduino UNOとCanzasiボード(非売品。オープンソースデータをもとに自作が必要)が必要です。</span></div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="https://github.com/tadfmac/Canzasi">Canzasi Prot</a> ）x 1</li>
+          <li><a href="https://github.com/tadfmac/Canzasi">Canzasi Wrtr</a> ）x 1</li>
+          <li><a href="https://www.switch-science.com/catalog/789/">Arduino UNO Rev.3</a> x 1</li>
+          <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 2</li>
+        </ul>
+      </div>
     </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">Arduino経由でI2Cデバイスが作れるオープンソースハードウエア「<a href="https://github.com/tadfmac/Canzasi">Canzasi</a>」の接続例です。<br><span style="font-size:11px">Canzasiを利用するためには、Arduino UNOとCanzasiボード(非売品。オープンソースデータをもとに自作が必要)が必要です。</span></div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="https://github.com/tadfmac/Canzasi">Canzasi Prot</a> ）x 1</li>
-        <li><a href="https://github.com/tadfmac/Canzasi">Canzasi Wrtr</a> ）x 1</li>
-        <li><a href="https://www.switch-science.com/catalog/789/">Arduino UNO Rev.3</a> x 1</li>
-        <li><a href="https://www.switch-science.com/catalog/1048/">Grove - ジャンパー（メス）ケーブル</a> x 2</li>
-      </ul>
-    </div>
-  </div>
 
-  <div class="cwrap">
-    <div class="title">I2C-arduino-steppingMotor</div>
-    <div class="linkwrap">
-      <div class="linkicon schematic"><a href="../../i2c/i2c-arduino-steppingMotor/schematic.png" target="_blank">回路図</a></div>
-      <div class="linkicon local"><a href="../../i2c/i2c-arduino-steppingMotor/" target="_blank">Local</a></div>
-      <div class="linkicon api"><a href="../../i2c/i2c-arduino-steppingMotor/api.html" target="_blank">API</a></div>
+    <div class="cwrap">
+      <div class="title">I2C-arduino-steppingMotor</div>
+      <div class="linkwrap">
+        <div class="linkicon schematic"><a href="../../i2c/i2c-arduino-steppingMotor/schematic.png" target="_blank">回路図</a></div>
+        <div class="linkicon local"><a href="../../i2c/i2c-arduino-steppingMotor/" target="_blank">Local</a></div>
+        <div class="linkicon api"><a href="../../i2c/i2c-arduino-steppingMotor/api.html" target="_blank">API</a></div>
+        <div class="linkicon jsbin"><a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/examples/JSBinLinks/I2C-arduino-steppingMotor.md" target="_blank">JSBin</a></div>
+      </div>
+      <h3 class="sumally">概要</h3>
+      <div class="desc">Arduinoとモータードライバを経由してステッピングモータを動かすサンプルです。ステッピングモータを回すために必要なタイミングの制御に Arduino を I2C デバイスとして使用しています。このサンプルでは回転方向を反転させながら2回転ずつモーターを回します。</div>
+      <h3 class="parts">使用パーツ</h3>
+      <div class="desc">
+        <ul>
+          <li><a href="https://www.switch-science.com/catalog/789/">Arduino UNO Rev.3</a> x 1</li>
+          <li><a href="https://www.switch-science.com/catalog/2242/">EasyDriver ステッピングモータドライバ</a> x 1</li>
+          <li><a href="http://akizukidenshi.com/catalog/g/gM-05825/">I2Cバス用双方向電圧レベル変換モジュール(FXMA2102)</a> x 1</li>
+          <li><a href="http://akizukidenshi.com/catalog/g/gP-05372/">バイポーラ　ステッピングモーターSM-42BYG011</a> x 1</li>
+          <li><a href="https://www.switch-science.com/catalog/1410/">ACアダプター 12V/1.5A</a> x 1</li>
+          <li><a href="https://www.switch-science.com/catalog/2321/">DCプラグ変換ケーブル（QIオス）</a> x 1</li>
+          <li>AE-FXMA2102とEasyDriverをブレッドボードに載せる場合:ジャンパー（オス・メス）ケーブル x 7、(オス・オス) x 7<br/>
+          モーターのワイヤーは圧着やはんだ付けで処理する必要があります。<br/>
+          また、Arduino には <a href="https://github.com/g200kg/arduino-stepping-motor">arduino-stepping-motor</a> のスケッチを書き込んでおきます。
+          <br></li>
+        </ul>
+      </div>
     </div>
-    <h3 class="sumally">概要</h3>
-    <div class="desc">Arduinoとモータードライバを経由してステッピングモータを動かすサンプルです。ステッピングモータを回すために必要なタイミングの制御に Arduino を I2C デバイスとして使用しています。このサンプルでは回転方向を反転させながら2回転ずつモーターを回します。</div>
-    <h3 class="parts">使用パーツ</h3>
-    <div class="desc">
-      <ul>
-        <li><a href="https://www.switch-science.com/catalog/789/">Arduino UNO Rev.3</a> x 1</li>
-        <li><a href="https://www.switch-science.com/catalog/2242/">EasyDriver ステッピングモータドライバ</a> x 1</li>
-        <li><a href="http://akizukidenshi.com/catalog/g/gM-05825/">I2Cバス用双方向電圧レベル変換モジュール(FXMA2102)</a> x 1</li>
-        <li><a href="http://akizukidenshi.com/catalog/g/gP-05372/">バイポーラ　ステッピングモーターSM-42BYG011</a> x 1</li>
-        <li><a href="https://www.switch-science.com/catalog/1410/">ACアダプター 12V/1.5A</a> x 1</li>
-        <li><a href="https://www.switch-science.com/catalog/2321/">DCプラグ変換ケーブル（QIオス）</a> x 1</li>
-        <li>AE-FXMA2102とEasyDriverをブレッドボードに載せる場合:ジャンパー（オス・メス）ケーブル x 7、(オス・オス) x 7<br/>
-        モーターのワイヤーは圧着やはんだ付けで処理する必要があります。<br/>
-        また、Arduino には <a href="https://github.com/g200kg/arduino-stepping-motor">arduino-stepping-motor</a> のスケッチを書き込んでおきます。
-        <br></li>
-      </ul>
-    </div>
-  </div>
 
+  </div>
 </div>
-</div>
+
 <div id="bwrap">
-<div id="bfooter">CHIRIMEN for Raspberry Pi ver.2018/03/08</div>
-
+  <div id="bfooter">CHIRIMEN for Raspberry Pi ver.2018/09/10</div>
 </div>
 
 </body>

--- a/gc/top/index.html
+++ b/gc/top/index.html
@@ -80,7 +80,10 @@ img{
     <div id="left-wrap">
       <div class="titlebox"><img src="./img/title.png"></div>
       <div class="inbox">
+        <a href="https://github.com/chirimen-oh/tutorials/blob/master/RaspberryPi/JA/readme.md"><img src="./img/tutorial.png"></a>
+        <!--
         <a href="https://qiita.com/tadfmac/items/82817476615fdc7394b3"><img src="./img/tutorial.png"></a>
+        -->
       </div>
     </div>
     <div id="right-wrap">


### PR DESCRIPTION
* チュートリアルのリンクをgithubのほう(全てasync await統一版)に切り替えました。
* 新しく追加されたexamplesをindexに追加しました。
* examplesのindexのJSBINのリンクを直リンクではなく中継コンテンツ(今後はこれをさらに短縮URLサービスにチェンジしましょう)に置き換えました。