### PR TITLE
chromiumのbluetoothを初期状態で有効化

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -101,7 +101,9 @@ sudo sed 's/\/etc\/ssl\/private\/ssl-cert-snakeoil\.key/\/home\/pi\/_gc\/srv\/cr
 sudo a2ensite vhost-ssl
 sudo a2enmod ssl
 sudo systemctl restart apache2
-echo '@/usr/bin/chromium-browser https://localhost/top' >> /home/pi/.config/lxsession/LXDE-pi/autostart
+echo '@/usr/bin/chromium-browser https://localhost/top --enable-experimental-web-platform-features' >> /home/pi/.config/lxsession/LXDE-pi/autostart
+sudo sed 's/Exec=\/usr\/bin\/x-www-browser\s%u/Exec=\/usr\/bin\/x-www-browser --enable-experimental-web-platform-features %u/g' /usr/share/raspi-ui-overrides/applications/lxde-x-www-browser.desktop | sudo tee /tmp/xbrowser && sudo cat /tmp/xbrowser | sudo tee /usr/share/raspi-ui-overrides/applications/lxde-x-www-browser.desktop && sudo rm -f /tmp/xbrowser
+sudo sed 's/Exec=chromium-browser/Exec=chromium-browser --enable-experimental-web-platform-features/g' /usr/share/applications/chromium-browser.desktop | sudo tee /tmp/chbrowser && sudo cat /tmp/chbrowser | sudo tee /usr/share/applications/chromium-browser.desktop && sudo rm -f /tmp/chbrowser
 
 # 証明書追加
 certfile="/home/pi/_gc/srv/crt/ca.crt"


### PR DESCRIPTION
setup-jaより4-5. Web Bluetooth APIの有効化をスクリプト化